### PR TITLE
Implement predictive coding forward pass

### DIFF
--- a/bio_snn/network.py
+++ b/bio_snn/network.py
@@ -1,36 +1,54 @@
 import numpy as np
 from .neuron import SpikingNeuron
-from .plasticity import STDP
+from .plasticity import STDP, SynapticScaling
 
 class Layer:
     def __init__(self, n_in, n_neurons):
         self.weights = np.random.randn(n_neurons, n_in) * 0.1
         self.neurons = [SpikingNeuron() for _ in range(n_neurons)]
         self.stdp = STDP()
+        self.scaling = SynapticScaling()
         self.pre_traces = np.zeros((n_neurons, n_in))
         self.post_traces = np.zeros(n_neurons)
+        self.avg_rates = np.zeros(n_neurons)
+        self.tau_rate = 100.0
 
-    def forward(self, x):
+    def forward(self, x, modulation=1.0):
         outputs = []
         for i, neuron in enumerate(self.neurons):
             inp = self.weights[i] * x
             spike = neuron.forward(inp)
             outputs.append(spike)
-            # update plasticity
+
+            # update plasticity with neuromodulation
             for j, pre in enumerate(x):
                 self.weights[i, j], self.pre_traces[i, j], self.post_traces[i] = (
-                    self.stdp.update(self.weights[i, j], pre, spike, self.pre_traces[i, j], self.post_traces[i])
+                    self.stdp.update(
+                        self.weights[i, j],
+                        pre,
+                        spike,
+                        self.pre_traces[i, j],
+                        self.post_traces[i],
+                        modulation=modulation,
+                    )
                 )
+
+            # update firing rate estimate
+            self.avg_rates[i] += (spike - self.avg_rates[i]) / self.tau_rate
+            # apply synaptic scaling
+            self.weights[i] = self.scaling.update(self.weights[i], self.avg_rates[i])
+
         return np.array(outputs)
 
 class Network:
     """Simple feedforward SNN with STDP and predictive coding."""
+
     def __init__(self, sizes):
         self.layers = []
         for n_in, n_out in zip(sizes[:-1], sizes[1:]):
             self.layers.append(Layer(n_in, n_out))
 
-    def forward(self, x):
+    def forward(self, x, modulation=1.0):
         for layer in self.layers:
-            x = layer.forward(x)
+            x = layer.forward(x, modulation=modulation)
         return x

--- a/bio_snn/plasticity.py
+++ b/bio_snn/plasticity.py
@@ -1,15 +1,29 @@
 import numpy as np
 
 class STDP:
-    """Spike-Timing-Dependent Plasticity."""
+    """Spike-Timing-Dependent Plasticity with optional neuromodulation."""
+
     def __init__(self, lr=0.01, tau_pre=20.0, tau_post=20.0):
         self.lr = lr
         self.tau_pre = tau_pre
         self.tau_post = tau_post
 
-    def update(self, w, pre_spike, post_spike, pre_trace, post_trace):
+    def update(self, w, pre_spike, post_spike, pre_trace, post_trace, modulation=1.0):
+        """Update a synapse given pre/post spikes and traces."""
         pre_trace = pre_trace * np.exp(-1.0 / self.tau_pre) + pre_spike
         post_trace = post_trace * np.exp(-1.0 / self.tau_post) + post_spike
-        dw = self.lr * (pre_spike * post_trace - post_spike * pre_trace)
+        dw = modulation * self.lr * (pre_spike * post_trace - post_spike * pre_trace)
         w += dw
         return w, pre_trace, post_trace
+
+
+class SynapticScaling:
+    """Homeostatic synaptic scaling to maintain target firing rates."""
+
+    def __init__(self, target=0.1, lr=0.001):
+        self.target = target
+        self.lr = lr
+
+    def update(self, weights, rate):
+        scale = 1.0 + self.lr * (self.target - rate)
+        return weights * scale

--- a/tests/test_predictive_coding.py
+++ b/tests/test_predictive_coding.py
@@ -1,0 +1,9 @@
+import numpy as np
+from bio_snn.predictive_coding import PredictiveCodingNetwork
+
+
+def test_predictive_forward_runs():
+    net = PredictiveCodingNetwork([2, 3, 1])
+    x = np.array([0.5, -0.5])
+    out = net.forward(x)
+    assert out.shape == (1,)


### PR DESCRIPTION
## Summary
- add homeostatic synaptic scaling
- support neuromodulation for STDP
- propagate modulation through network and predictive coding model
- add simple predictive coding test

## Testing
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c3c882eb8832c905591cc03dc76f9