### PR TITLE
Improve research usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ for experimenting with more elaborate models that incorporate dendritic
 computation, neuromodulation and hierarchical organization as described in the
 project proposal.
 
+Recent refactoring introduced reproducible initialization and state reset
+functions making the code easier to use for controlled experiments.
+
 ## Basic Usage
 
 Install dependencies:
@@ -45,7 +48,9 @@ continual learning tasks or robustness benchmarks are natural next steps.
 A simple CLI is provided to quickly run a simulation without writing any code. Example usage:
 
 ```bash
-python -m bio_snn.interface --sizes 2,3,1 --input 1,0 --steps 100
+python -m bio_snn.interface --sizes 2,3,1 --input 1,0 --steps 100 --seed 0
 ```
 
 This will construct a small network with the given layer sizes, feed the input vector for 100 steps and print the final output.
+Providing a ``--seed`` ensures reproducible results, while ``--modulation`` can
+be used to adjust the strength of plasticity online.

--- a/bio_snn/interface.py
+++ b/bio_snn/interface.py
@@ -3,8 +3,10 @@ import numpy as np
 from .predictive_coding import PredictiveCodingNetwork
 
 
-def run_simulation(sizes, input_vec, steps, modulation=1.0):
+def run_simulation(sizes, input_vec, steps, modulation=1.0, seed=None):
     """Run a predictive coding network for a number of steps."""
+    if seed is not None:
+        np.random.seed(seed)
     net = PredictiveCodingNetwork(sizes)
     x = np.array(input_vec, dtype=float)
     for _ in range(steps):
@@ -41,11 +43,23 @@ def main(args=None):
         default=1.0,
         help="Neuromodulation factor",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility",
+    )
     parsed = parser.parse_args(args)
 
     sizes = [int(s) for s in parsed.sizes.split(",")]
     input_vec = [float(v) for v in parsed.input.split(",")]
-    run_simulation(sizes, input_vec, parsed.steps, modulation=parsed.modulation)
+    run_simulation(
+        sizes,
+        input_vec,
+        parsed.steps,
+        modulation=parsed.modulation,
+        seed=parsed.seed,
+    )
 
 
 if __name__ == "__main__":

--- a/bio_snn/neuron.py
+++ b/bio_snn/neuron.py
@@ -1,16 +1,28 @@
+"""Spiking neuron models used by the network."""
+
+from dataclasses import dataclass, field
 import numpy as np
 
+
+@dataclass
 class SpikingNeuron:
     """A simple spiking neuron with adaptive threshold and two compartments."""
 
-    def __init__(self, n_dendrites=2, tau_mem=10.0, tau_thresh=20.0, v_reset=0.0, v_thresh=1.0):
-        self.n_dendrites = n_dendrites
-        self.v = v_reset
-        self.threshold = v_thresh
-        self.v_reset = v_reset
-        self.tau_mem = tau_mem
-        self.tau_thresh = tau_thresh
-        self.last_spike = -np.inf
+    n_dendrites: int = 2
+    tau_mem: float = 10.0
+    tau_thresh: float = 20.0
+    v_reset: float = 0.0
+    v_thresh: float = 1.0
+
+    v: float = field(init=False)
+    threshold: float = field(init=False)
+    last_spike: float = field(default=-np.inf, init=False)
+    baseline_thresh: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.v = self.v_reset
+        self.threshold = self.v_thresh
+        self.baseline_thresh = self.v_thresh
 
     def forward(self, inputs, dt=1.0):
         """Integrate inputs and return spike (0/1)."""
@@ -26,3 +38,9 @@ class SpikingNeuron:
         if self.last_spike != -np.inf:
             self.last_spike += dt
         return 0
+
+    def reset(self) -> None:
+        """Reset membrane potential and adaptive threshold."""
+        self.v = self.v_reset
+        self.threshold = self.baseline_thresh
+        self.last_spike = -np.inf

--- a/bio_snn/plasticity.py
+++ b/bio_snn/plasticity.py
@@ -1,12 +1,16 @@
+"""Plasticity mechanisms used in the spiking network."""
+
+from dataclasses import dataclass
 import numpy as np
 
+
+@dataclass
 class STDP:
     """Spike-Timing-Dependent Plasticity with optional neuromodulation."""
 
-    def __init__(self, lr=0.01, tau_pre=20.0, tau_post=20.0):
-        self.lr = lr
-        self.tau_pre = tau_pre
-        self.tau_post = tau_post
+    lr: float = 0.01
+    tau_pre: float = 20.0
+    tau_post: float = 20.0
 
     def update(self, w, pre_spike, post_spike, pre_trace, post_trace, modulation=1.0):
         """Update a synapse given pre/post spikes and traces."""
@@ -17,12 +21,12 @@ class STDP:
         return w, pre_trace, post_trace
 
 
+@dataclass
 class SynapticScaling:
     """Homeostatic synaptic scaling to maintain target firing rates."""
 
-    def __init__(self, target=0.1, lr=0.001):
-        self.target = target
-        self.lr = lr
+    target: float = 0.1
+    lr: float = 0.001
 
     def update(self, weights, rate):
         scale = 1.0 + self.lr * (self.target - rate)

--- a/bio_snn/predictive_coding.py
+++ b/bio_snn/predictive_coding.py
@@ -31,3 +31,9 @@ class PredictiveCodingNetwork(Network):
             activations.append(err)
 
         return activations[-1]
+
+    def reset_state(self) -> None:
+        """Reset network and prediction weights."""
+        super().reset_state()
+        for w in self.pred_weights:
+            w.fill(0)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -10,3 +10,10 @@ def test_cli_simulation_runs():
     )
     assert result.returncode == 0
     assert 'Output:' in result.stdout
+
+
+def test_cli_seed_reproducible():
+    args = [sys.executable, '-m', 'bio_snn.interface', '--sizes', '2,3,1', '--input', '1,0', '--steps', '5', '--seed', '42']
+    r1 = subprocess.run(args, capture_output=True, text=True).stdout
+    r2 = subprocess.run(args, capture_output=True, text=True).stdout
+    assert r1 == r2

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -7,3 +7,13 @@ def test_neuron_spikes():
     for _ in range(50):
         spikes.append(n.forward([2.0]))
     assert any(spikes)
+
+
+def test_reset_restores_baseline():
+    n = SpikingNeuron()
+    for _ in range(10):
+        n.forward([2.0])
+    assert n.v != n.v_reset or n.threshold != n.baseline_thresh
+    n.reset()
+    assert n.v == n.v_reset
+    assert n.threshold == n.baseline_thresh

--- a/tests/test_predictive_coding.py
+++ b/tests/test_predictive_coding.py
@@ -7,3 +7,13 @@ def test_predictive_forward_runs():
     x = np.array([0.5, -0.5])
     out = net.forward(x)
     assert out.shape == (1,)
+
+
+def test_network_reset_clears_traces():
+    net = PredictiveCodingNetwork([2, 3, 1])
+    # manually set traces to mimic activity
+    for layer in net.layers:
+        layer.post_traces.fill(1.0)
+    assert any(layer.post_traces.any() for layer in net.layers)
+    net.reset_state()
+    assert all(not layer.post_traces.any() for layer in net.layers)


### PR DESCRIPTION
## Summary
- refactor spiking neuron and plasticity into dataclasses
- add state reset utilities to neurons, layers and networks
- allow reproducible runs in CLI via `--seed`
- update docs with new options
- add tests covering reset functions and reproducibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c42765370832c86e0d1d90aec4ccd