### PR TITLE
Add basic energy-based training module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ implements several biologically motivated mechanisms:
 - **Spike-Timing-Dependent Plasticity (STDP)** learning rule.
 - A small **predictive coding** network that attempts to minimize local
   prediction errors between layers.
+- A simple **energy-based** network for gradient descent experiments.
 
 The implementation is intentionally lightweight and serves as a starting point
 for experimenting with more elaborate models that incorporate dendritic
@@ -25,7 +26,7 @@ Install dependencies:
 pip install numpy matplotlib
 ```
 
-Run a short simulation:
+Run a short simulation with the predictive coding network:
 
 ```python
 from bio_snn.predictive_coding import PredictiveCodingNetwork
@@ -40,17 +41,33 @@ print("Output:", y)
 ```
 
 This will create a tiny network with one hidden layer and run it for a few
-steps. Extending the model with more detailed neuron dynamics and testing it on
-continual learning tasks or robustness benchmarks are natural next steps.
+steps.
+
+An additional ``EnergyNetwork`` class demonstrates energy-based training with
+backpropagation. Example:
+
+```python
+from bio_snn.energy_based import EnergyNetwork
+import numpy as np
+
+net = EnergyNetwork([2, 4, 1])
+x = np.array([1.0, -1.0])
+target = np.array([0.5])
+for _ in range(50):
+    net.train_step(x, target)
+print("Energy:", net.energy(x, target))
+```
 
 ## Command Line Interface
 
-A simple CLI is provided to quickly run a simulation without writing any code. Example usage:
+A simple CLI is provided to quickly run a simulation without writing any code.
+Example usage:
 
 ```bash
 python -m bio_snn.interface --sizes 2,3,1 --input 1,0 --steps 100 --seed 0
 ```
 
-This will construct a small network with the given layer sizes, feed the input vector for 100 steps and print the final output.
-Providing a ``--seed`` ensures reproducible results, while ``--modulation`` can
-be used to adjust the strength of plasticity online.
+This will construct a small network with the given layer sizes, feed the input
+vector for 100 steps and print the final output.  Providing a ``--seed`` ensures
+reproducible results, while ``--modulation`` can be used to adjust the strength
+of plasticity online.

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -3,11 +3,13 @@
 from .neuron import SpikingNeuron
 from .network import Network
 from .predictive_coding import PredictiveCodingNetwork
+from .energy_based import EnergyNetwork
 from .interface import run_simulation
 
 __all__ = [
     "SpikingNeuron",
     "Network",
     "PredictiveCodingNetwork",
+    "EnergyNetwork",
     "run_simulation",
 ]

--- a/bio_snn/energy_based.py
+++ b/bio_snn/energy_based.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+class EnergyNetwork:
+    """Simple energy-based network with gradient descent training."""
+
+    def __init__(self, sizes, reg=1e-4):
+        self.weights = [
+            np.random.randn(n_out, n_in) * 0.1
+            for n_in, n_out in zip(sizes[:-1], sizes[1:])
+        ]
+        self.reg = reg
+
+    def forward(self, x):
+        """Forward pass with tanh activations."""
+        for w in self.weights[:-1]:
+            x = np.tanh(w @ x)
+        return self.weights[-1] @ x
+
+    def energy(self, x, target):
+        """Compute global energy for input and target."""
+        out = self.forward(x)
+        mse = 0.5 * np.sum((out - target) ** 2)
+        reg_term = 0.5 * self.reg * sum(np.sum(w ** 2) for w in self.weights)
+        return mse + reg_term
+
+    def train_step(self, x, target, lr=0.01):
+        """Perform one gradient descent step to minimize energy."""
+        activations = [x]
+        for w in self.weights[:-1]:
+            activations.append(np.tanh(w @ activations[-1]))
+        out = self.weights[-1] @ activations[-1]
+        error = out - target
+
+        # Backpropagate gradients
+        grad_out = error
+        grads = []
+        for i in reversed(range(len(self.weights))):
+            a_prev = activations[i]
+            grad_w = np.outer(grad_out, a_prev) + self.reg * self.weights[i]
+            grads.insert(0, grad_w)
+            if i > 0:
+                grad_a = self.weights[i].T @ grad_out
+                grad_out = grad_a * (1 - activations[i] ** 2)
+
+        # Update weights
+        for w, g in zip(self.weights, grads):
+            w -= lr * g
+
+        return np.linalg.norm(error)
+

--- a/tests/test_energy_based.py
+++ b/tests/test_energy_based.py
@@ -1,0 +1,20 @@
+import numpy as np
+from bio_snn.energy_based import EnergyNetwork
+
+
+def test_energy_forward_shape():
+    net = EnergyNetwork([2, 3, 1])
+    x = np.array([0.5, -0.5])
+    out = net.forward(x)
+    assert out.shape == (1,)
+
+
+def test_training_reduces_energy():
+    net = EnergyNetwork([2, 4, 1])
+    x = np.array([1.0, -1.0])
+    target = np.array([0.5])
+    e1 = net.energy(x, target)
+    for _ in range(50):
+        net.train_step(x, target, lr=0.05)
+    e2 = net.energy(x, target)
+    assert e2 < e1


### PR DESCRIPTION
## Summary
- export an `EnergyNetwork` module
- create `EnergyNetwork` class implementing gradient-descent learning
- mention `EnergyNetwork` in README with example usage
- test the energy-based network

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c430af33c832cb66a5c71dc33f7c2