### PR TITLE
Add modular layers and network architecture

### DIFF
--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -4,6 +4,8 @@ from .neuron import SpikingNeuron
 from .network import Network
 from .predictive_coding import PredictiveCodingNetwork
 from .energy_based import EnergyNetwork
+from .modular_network import ModularEnergyNetwork
+from .layers import DenseLayer, ConvLayer, FlattenLayer, RecurrentLayer
 from .interface import run_simulation
 
 __all__ = [
@@ -11,5 +13,10 @@ __all__ = [
     "Network",
     "PredictiveCodingNetwork",
     "EnergyNetwork",
+    "ModularEnergyNetwork",
+    "DenseLayer",
+    "ConvLayer",
+    "FlattenLayer",
+    "RecurrentLayer",
     "run_simulation",
 ]

--- a/bio_snn/layers.py
+++ b/bio_snn/layers.py
@@ -1,0 +1,143 @@
+"""Modular neural network layers for energy-based models."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class BaseLayer:
+    """Abstract base layer."""
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def backward(self, grad: np.ndarray) -> np.ndarray:
+        """Return gradient w.r.t. input and accumulate parameter grads."""
+        raise NotImplementedError
+
+    def update(self, lr: float) -> None:
+        pass
+
+    def reset_state(self) -> None:
+        pass
+
+
+class DenseLayer(BaseLayer):
+    """Simple fully connected layer."""
+
+    def __init__(self, n_in: int, n_out: int) -> None:
+        self.weight = np.random.randn(n_out, n_in) * 0.1
+        self.grad_w = np.zeros_like(self.weight)
+        self.x: np.ndarray | None = None
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        self.x = x
+        return self.weight @ x
+
+    def backward(self, grad: np.ndarray) -> np.ndarray:
+        self.grad_w = np.outer(grad, self.x)
+        return self.weight.T @ grad
+
+    def update(self, lr: float) -> None:
+        self.weight -= lr * self.grad_w
+
+
+class ConvLayer(BaseLayer):
+    """Naive 2D convolution for single or multi-channel inputs."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int) -> None:
+        self.weight = np.random.randn(out_channels, in_channels, kernel_size, kernel_size) * 0.1
+        self.grad_w = np.zeros_like(self.weight)
+        self.kernel_size = kernel_size
+        self.x: np.ndarray | None = None
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        """x shape: (C, H, W)."""
+        self.x = x
+        C, H, W = x.shape
+        F = self.weight.shape[0]
+        k = self.kernel_size
+        H_out = H - k + 1
+        W_out = W - k + 1
+        out = np.zeros((F, H_out, W_out))
+        for f in range(F):
+            for c in range(C):
+                w = self.weight[f, c]
+                for i in range(H_out):
+                    for j in range(W_out):
+                        region = x[c, i : i + k, j : j + k]
+                        out[f, i, j] += np.sum(region * w)
+        return out
+
+    def backward(self, grad: np.ndarray) -> np.ndarray:
+        x = self.x
+        assert x is not None
+        C, H, W = x.shape
+        F = self.weight.shape[0]
+        k = self.kernel_size
+        H_out = H - k + 1
+        W_out = W - k + 1
+        self.grad_w.fill(0)
+        grad_x = np.zeros_like(x)
+        for f in range(F):
+            for c in range(C):
+                w = self.weight[f, c]
+                for i in range(H_out):
+                    for j in range(W_out):
+                        region = x[c, i : i + k, j : j + k]
+                        self.grad_w[f, c] += grad[f, i, j] * region
+                        grad_x[c, i : i + k, j : j + k] += grad[f, i, j] * w
+        return grad_x
+
+    def update(self, lr: float) -> None:
+        self.weight -= lr * self.grad_w
+
+
+class FlattenLayer(BaseLayer):
+    """Flatten arbitrary input to a 1D vector."""
+
+    def __init__(self) -> None:
+        self.shape: tuple[int, ...] | None = None
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        self.shape = x.shape
+        return x.ravel()
+
+    def backward(self, grad: np.ndarray) -> np.ndarray:
+        assert self.shape is not None
+        return grad.reshape(self.shape)
+
+
+class RecurrentLayer(BaseLayer):
+    """Simple recurrent layer with tanh activation."""
+
+    def __init__(self, n_in: int, n_hidden: int) -> None:
+        self.w_in = np.random.randn(n_hidden, n_in) * 0.1
+        self.w_rec = np.random.randn(n_hidden, n_hidden) * 0.1
+        self.h = np.zeros(n_hidden)
+        self.grad_w_in = np.zeros_like(self.w_in)
+        self.grad_w_rec = np.zeros_like(self.w_rec)
+        self.x: np.ndarray | None = None
+        self.prev_h: np.ndarray | None = None
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        self.x = x
+        self.prev_h = self.h.copy()
+        self.h = np.tanh(self.w_in @ x + self.w_rec @ self.h)
+        return self.h
+
+    def backward(self, grad: np.ndarray) -> np.ndarray:
+        dtanh = (1 - self.h ** 2) * grad
+        assert self.x is not None and self.prev_h is not None
+        self.grad_w_in = np.outer(dtanh, self.x)
+        self.grad_w_rec = np.outer(dtanh, self.prev_h)
+        grad_x = self.w_in.T @ dtanh
+        self.h = self.prev_h  # restore previous state for truncated BPTT
+        return grad_x
+
+    def update(self, lr: float) -> None:
+        self.w_in -= lr * self.grad_w_in
+        self.w_rec -= lr * self.grad_w_rec
+
+    def reset_state(self) -> None:
+        self.h.fill(0)

--- a/bio_snn/modular_network.py
+++ b/bio_snn/modular_network.py
@@ -1,0 +1,49 @@
+"""Energy-based network supporting multiple layer types."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .layers import BaseLayer
+
+
+class ModularEnergyNetwork:
+    """Flexible energy-based network using pluggable layers."""
+
+    def __init__(self, layers: list[BaseLayer], reg: float = 1e-4) -> None:
+        self.layers = layers
+        self.reg = reg
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        for layer in self.layers[:-1]:
+            x = np.tanh(layer.forward(x))
+        return self.layers[-1].forward(x)
+
+    def energy(self, x: np.ndarray, target: np.ndarray) -> float:
+        out = self.forward(x)
+        mse = 0.5 * np.sum((out - target) ** 2)
+        reg_term = 0.5 * self.reg * sum(
+            np.sum(getattr(layer, "weight") ** 2)
+            for layer in self.layers
+            if hasattr(layer, "weight")
+        )
+        return mse + reg_term
+
+    def train_step(self, x: np.ndarray, target: np.ndarray, lr: float = 0.01) -> float:
+        activations = [x]
+        for layer in self.layers[:-1]:
+            activations.append(np.tanh(layer.forward(activations[-1])))
+        out = self.layers[-1].forward(activations[-1])
+        error = out - target
+        grad = error
+        grad = self.layers[-1].backward(grad)
+        for i in range(len(self.layers) - 2, -1, -1):
+            grad = grad * (1 - activations[i + 1] ** 2)
+            grad = self.layers[i].backward(grad)
+        for layer in self.layers:
+            layer.update(lr)
+        return np.linalg.norm(error)
+
+    def reset_state(self) -> None:
+        for layer in self.layers:
+            layer.reset_state()

--- a/tests/test_modular_network.py
+++ b/tests/test_modular_network.py
@@ -1,0 +1,37 @@
+import numpy as np
+from bio_snn.modular_network import ModularEnergyNetwork
+from bio_snn.layers import DenseLayer, ConvLayer, FlattenLayer, RecurrentLayer
+
+
+def test_conv_forward_shape():
+    conv = ConvLayer(1, 2, kernel_size=2)
+    flat = FlattenLayer()
+    dense = DenseLayer(18, 1)  # output 2*(3*3) = 18 for 4x4 input
+    net = ModularEnergyNetwork([conv, flat, dense])
+    x = np.random.randn(1, 4, 4)
+    out = net.forward(x)
+    assert out.shape == (1,)
+
+
+def test_recurrent_state_update():
+    rnn = RecurrentLayer(1, 3)
+    dense = DenseLayer(3, 1)
+    net = ModularEnergyNetwork([rnn, dense])
+    x1 = np.array([0.5])
+    out1 = net.forward(x1)
+    x2 = np.array([-0.2])
+    out2 = net.forward(x2)
+    assert out1.shape == out2.shape == (1,)
+    assert not np.allclose(out1, out2)
+
+
+def test_modular_training_reduces_energy():
+    layers = [DenseLayer(2, 3), DenseLayer(3, 1)]
+    net = ModularEnergyNetwork(layers)
+    x = np.array([1.0, -1.0])
+    target = np.array([0.5])
+    e1 = net.energy(x, target)
+    for _ in range(50):
+        net.train_step(x, target, lr=0.05)
+    e2 = net.energy(x, target)
+    assert e2 < e1


### PR DESCRIPTION
## Summary
- add pluggable layers including convolutional, recurrent, dense, and flatten
- create new `ModularEnergyNetwork` supporting arbitrary layer stacks
- expose new classes via package `__init__`
- test convolutional, recurrent, and training functionality in new network

## Testing
- `pip install numpy matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c45345d40832c817aad288283994d