### PR TITLE
Add dataset support and training utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ for _ in range(50):
 print("Energy:", net.energy(x, target))
 ```
 
+For larger scale experiments you can train the network on the
+``sklearn`` digits dataset using the provided ``EnergyTrainer`` utility:
+
+```python
+from bio_snn.training import EnergyTrainer, TrainingConfig
+
+cfg = TrainingConfig(sizes=[64, 32, 10], lr=0.05, epochs=5)
+trainer = EnergyTrainer(cfg)
+trainer.train()
+```
+
+This will load the dataset, run several training epochs while logging loss
+values, save checkpoints in ``./checkpoints`` and produce a ``training_loss.png``
+plot for quick visualization.
+
 ## Command Line Interface
 
 A simple CLI is provided to quickly run a simulation without writing any code.

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -5,6 +5,8 @@ from .network import Network
 from .predictive_coding import PredictiveCodingNetwork
 from .energy_based import EnergyNetwork
 from .interface import run_simulation
+from .datasets import load_digits_dataset
+from .training import EnergyTrainer, TrainingConfig
 
 __all__ = [
     "SpikingNeuron",
@@ -12,4 +14,7 @@ __all__ = [
     "PredictiveCodingNetwork",
     "EnergyNetwork",
     "run_simulation",
+    "load_digits_dataset",
+    "EnergyTrainer",
+    "TrainingConfig",
 ]

--- a/bio_snn/datasets/__init__.py
+++ b/bio_snn/datasets/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset loaders and preprocessing utilities for standard ML datasets."""
+
+from .digits import load_digits_dataset
+
+__all__ = ["load_digits_dataset"]

--- a/bio_snn/datasets/digits.py
+++ b/bio_snn/datasets/digits.py
@@ -1,0 +1,39 @@
+"""Utilities for loading and preprocessing the sklearn digits dataset."""
+
+from typing import Tuple
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+
+def load_digits_dataset(test_size: float = 0.25, random_state: int | None = None
+                        ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load digits dataset and return normalized train/test splits.
+
+    Parameters
+    ----------
+    test_size: float, default 0.25
+        Fraction of the dataset to reserve for testing.
+    random_state: int or None, optional
+        Random seed for reproducibility of the train/test split.
+
+    Returns
+    -------
+    X_train: array, shape (n_train_samples, n_features)
+    X_test: array, shape (n_test_samples, n_features)
+    y_train: array, shape (n_train_samples,)
+    y_test: array, shape (n_test_samples,)
+    """
+    data = load_digits()
+    X = data.data.astype(float)
+    y = data.target.astype(int)
+
+    # normalize features to zero mean and unit variance
+    scaler = StandardScaler()
+    X = scaler.fit_transform(X)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
+    return X_train, X_test, y_train, y_test

--- a/bio_snn/training.py
+++ b/bio_snn/training.py
@@ -1,0 +1,80 @@
+"""Utilities for training networks on datasets with logging and checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .energy_based import EnergyNetwork
+from .datasets import load_digits_dataset
+
+
+@dataclass
+class TrainingConfig:
+    sizes: Iterable[int]
+    lr: float = 0.01
+    epochs: int = 10
+    batch_size: int = 32
+    checkpoint_dir: str | Path = "checkpoints"
+    log_interval: int = 1
+    random_state: int | None = None
+
+
+class EnergyTrainer:
+    """Trainer for EnergyNetwork on the digits dataset."""
+
+    def __init__(self, config: TrainingConfig) -> None:
+        self.config = config
+        self.net = EnergyNetwork(list(config.sizes))
+        (self.X_train,
+         self.X_test,
+         self.y_train,
+         self.y_test) = load_digits_dataset(random_state=config.random_state)
+        self.checkpoint_dir = Path(config.checkpoint_dir)
+        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        self.history: list[float] = []
+
+    def _batch_iter(self) -> Iterable[Tuple[np.ndarray, np.ndarray]]:
+        idx = np.random.permutation(len(self.X_train))
+        for start in range(0, len(idx), self.config.batch_size):
+            batch_idx = idx[start : start + self.config.batch_size]
+            x = self.X_train[batch_idx]
+            y = self.y_train[batch_idx]
+            yield x, y
+
+    def _save_checkpoint(self, epoch: int) -> None:
+        path = self.checkpoint_dir / f"epoch_{epoch}.npz"
+        np.savez(path, *self.net.weights)
+
+    def train(self) -> None:
+        for epoch in range(1, self.config.epochs + 1):
+            epoch_loss = 0.0
+            for x_batch, y_batch in self._batch_iter():
+                for x, target in zip(x_batch, y_batch):
+                    # one-hot encode target
+                    t = np.zeros(self.config.sizes[-1])
+                    t[target] = 1.0
+                    loss = self.net.train_step(x, t, lr=self.config.lr)
+                    epoch_loss += loss
+            avg_loss = epoch_loss / len(self.X_train)
+            self.history.append(avg_loss)
+            if epoch % self.config.log_interval == 0:
+                print(f"Epoch {epoch:03d}: loss={avg_loss:.4f}")
+            self._save_checkpoint(epoch)
+        self._plot_history()
+
+    def _plot_history(self) -> None:
+        plt.figure()
+        plt.plot(self.history, label="train loss")
+        plt.xlabel("Epoch")
+        plt.ylabel("Loss")
+        plt.title("Training Loss")
+        plt.legend()
+        plt.tight_layout()
+        plot_path = self.checkpoint_dir / "training_loss.png"
+        plt.savefig(plot_path)
+        plt.close()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,11 @@
+import numpy as np
+from bio_snn.datasets import load_digits_dataset
+
+
+def test_load_digits_dataset_shapes():
+    X_train, X_test, y_train, y_test = load_digits_dataset(test_size=0.2, random_state=0)
+    assert X_train.ndim == 2
+    assert X_train.shape[0] == y_train.shape[0]
+    assert X_test.shape[0] == y_test.shape[0]
+    # dataset should be standardized
+    assert np.allclose(X_train.mean(), 0, atol=1e-1)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,9 @@
+from bio_snn.training import EnergyTrainer, TrainingConfig
+
+
+def test_energy_trainer_runs(tmp_path):
+    cfg = TrainingConfig(sizes=[64, 16, 10], epochs=1, checkpoint_dir=tmp_path, lr=0.05)
+    trainer = EnergyTrainer(cfg)
+    trainer.train()
+    # check that a checkpoint file was created
+    assert any(tmp_path.glob("epoch_1.npz"))


### PR DESCRIPTION
## Summary
- implement dataset loader using `sklearn` digits
- add `EnergyTrainer` with checkpointing and plotting
- expose new utilities via package init
- document training example in README
- test dataset loader and training process

## Testing
- `pip install -q scikit-learn matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c453d60d0832c9c547592a0740cf7