### PR TITLE
Add simple builder API for spiking networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ print("Energy:", net.energy(x, target))
 ## High-Level API
 
 A small helper module simplifies building networks and running energy-based
-training schedules:
+training schedules.  It also lets you swap in custom neuron classes or energy
+functions:
 
 ```python
 from bio_snn.api import build_snn, LearningSchedule, train_energy
@@ -71,6 +72,20 @@ net = build_snn([2, 4, 1], network_type="energy")
 schedule = LearningSchedule(lr=0.05, epochs=20)
 train_energy(net, np.array([1.0, -1.0]), np.array([0.5]), schedule)
 print("Energy:", net.energy(np.array([1.0, -1.0]), np.array([0.5])))
+```
+
+To experiment with a different objective you can pass custom functions:
+
+```python
+def my_energy(out, target, weights, reg):
+    return 0.5 * np.sum((out - target) ** 2) + 0.1 * sum(np.sum(w**2) for w in weights)
+
+def my_grad(out, target):
+    return out - target
+
+net = build_snn(
+    [2, 4, 1], network_type="energy", energy_fn=my_energy, grad_fn=my_grad
+)
 ```
 
 ## Command Line Interface

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ for _ in range(50):
 print("Energy:", net.energy(x, target))
 ```
 
+## High-Level API
+
+A small helper module simplifies building networks and running energy-based
+training schedules:
+
+```python
+from bio_snn.api import build_snn, LearningSchedule, train_energy
+import numpy as np
+
+net = build_snn([2, 4, 1], network_type="energy")
+schedule = LearningSchedule(lr=0.05, epochs=20)
+train_energy(net, np.array([1.0, -1.0]), np.array([0.5]), schedule)
+print("Energy:", net.energy(np.array([1.0, -1.0]), np.array([0.5])))
+```
+
 ## Command Line Interface
 
 A simple CLI is provided to quickly run a simulation without writing any code.

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -5,11 +5,15 @@ from .network import Network
 from .predictive_coding import PredictiveCodingNetwork
 from .energy_based import EnergyNetwork
 from .interface import run_simulation
+from .api import build_snn, LearningSchedule, train_energy
 
 __all__ = [
     "SpikingNeuron",
     "Network",
     "PredictiveCodingNetwork",
     "EnergyNetwork",
+    "build_snn",
+    "LearningSchedule",
+    "train_energy",
     "run_simulation",
 ]

--- a/bio_snn/api.py
+++ b/bio_snn/api.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Sequence, Type, Callable, Optional
+import numpy as np
+
+from .neuron import SpikingNeuron
+from .network import Network
+from .predictive_coding import PredictiveCodingNetwork
+from .energy_based import EnergyNetwork
+
+
+@dataclass
+class LearningSchedule:
+    """Simple learning schedule for training loops."""
+
+    lr: float = 0.01
+    epochs: int = 1
+
+
+def build_snn(
+    sizes: Sequence[int],
+    *,
+    network_type: str = "predictive",
+    neuron_cls: Type[SpikingNeuron] = SpikingNeuron,
+    energy_fn: Optional[Callable] = None,
+    reg: float = 1e-4,
+):
+    """Create an SNN instance based on the requested type."""
+    if network_type == "predictive":
+        return PredictiveCodingNetwork(sizes, neuron_cls=neuron_cls)
+    if network_type == "feedforward":
+        return Network(sizes, neuron_cls=neuron_cls)
+    if network_type == "energy":
+        return EnergyNetwork(sizes, reg=reg, energy_fn=energy_fn)
+    raise ValueError(f"Unknown network_type: {network_type}")
+
+
+def train_energy(
+    net: EnergyNetwork,
+    x: np.ndarray,
+    target: np.ndarray,
+    schedule: LearningSchedule,
+):
+    """Train an EnergyNetwork according to the schedule."""
+    for _ in range(schedule.epochs):
+        net.train_step(x, target, lr=schedule.lr)

--- a/bio_snn/api.py
+++ b/bio_snn/api.py
@@ -22,15 +22,30 @@ def build_snn(
     network_type: str = "predictive",
     neuron_cls: Type[SpikingNeuron] = SpikingNeuron,
     energy_fn: Optional[Callable] = None,
+    grad_fn: Optional[Callable] = None,
     reg: float = 1e-4,
 ):
-    """Create an SNN instance based on the requested type."""
+    """Create an SNN instance based on the requested type.
+
+    Parameters
+    ----------
+    sizes : sequence of int
+        Layer sizes including input and output.
+    network_type : {"predictive", "feedforward", "energy"}
+        Which network class to construct.
+    neuron_cls : type
+        Spiking neuron implementation to use for network layers.
+    energy_fn, grad_fn : callables, optional
+        Custom energy function and derivative for ``EnergyNetwork``.
+    reg : float
+        Regularization strength for ``EnergyNetwork``.
+    """
     if network_type == "predictive":
         return PredictiveCodingNetwork(sizes, neuron_cls=neuron_cls)
     if network_type == "feedforward":
         return Network(sizes, neuron_cls=neuron_cls)
     if network_type == "energy":
-        return EnergyNetwork(sizes, reg=reg, energy_fn=energy_fn)
+        return EnergyNetwork(sizes, reg=reg, energy_fn=energy_fn, grad_fn=grad_fn)
     raise ValueError(f"Unknown network_type: {network_type}")
 
 
@@ -40,6 +55,6 @@ def train_energy(
     target: np.ndarray,
     schedule: LearningSchedule,
 ):
-    """Train an EnergyNetwork according to the schedule."""
+    """Train an ``EnergyNetwork`` according to ``schedule``."""
     for _ in range(schedule.epochs):
         net.train_step(x, target, lr=schedule.lr)

--- a/bio_snn/network.py
+++ b/bio_snn/network.py
@@ -1,6 +1,7 @@
 """Simple feedforward SNN architecture."""
 
 from dataclasses import dataclass, field
+from typing import Type
 import numpy as np
 from .neuron import SpikingNeuron
 from .plasticity import STDP, SynapticScaling
@@ -11,6 +12,7 @@ class Layer:
 
     n_in: int
     n_neurons: int
+    neuron_cls: Type[SpikingNeuron] = SpikingNeuron
     stdp: STDP = field(default_factory=STDP)
     scaling: SynapticScaling = field(default_factory=SynapticScaling)
     tau_rate: float = 100.0
@@ -23,7 +25,7 @@ class Layer:
 
     def __post_init__(self) -> None:
         self.weights = np.random.randn(self.n_neurons, self.n_in) * 0.1
-        self.neurons = [SpikingNeuron() for _ in range(self.n_neurons)]
+        self.neurons = [self.neuron_cls() for _ in range(self.n_neurons)]
         self.pre_traces = np.zeros((self.n_neurons, self.n_in))
         self.post_traces = np.zeros(self.n_neurons)
         self.avg_rates = np.zeros(self.n_neurons)
@@ -66,10 +68,10 @@ class Layer:
 class Network:
     """Simple feedforward SNN with STDP and predictive coding."""
 
-    def __init__(self, sizes):
+    def __init__(self, sizes, neuron_cls: Type[SpikingNeuron] = SpikingNeuron):
         self.layers = []
         for n_in, n_out in zip(sizes[:-1], sizes[1:]):
-            self.layers.append(Layer(n_in, n_out))
+            self.layers.append(Layer(n_in, n_out, neuron_cls=neuron_cls))
 
     def forward(self, x, modulation=1.0):
         for layer in self.layers:

--- a/bio_snn/predictive_coding.py
+++ b/bio_snn/predictive_coding.py
@@ -1,11 +1,12 @@
 import numpy as np
 from .network import Network
+from .neuron import SpikingNeuron
 
 class PredictiveCodingNetwork(Network):
     """Hierarchical network minimizing local prediction errors."""
 
-    def __init__(self, sizes, lr=0.01):
-        super().__init__(sizes)
+    def __init__(self, sizes, lr=0.01, neuron_cls=SpikingNeuron):
+        super().__init__(sizes, neuron_cls=neuron_cls)
         self.pred_weights = [np.zeros((sizes[i], sizes[i+1])) for i in range(len(sizes)-1)]
         self.lr = lr
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,20 @@
+import numpy as np
+from bio_snn.api import build_snn, LearningSchedule, train_energy
+
+
+def test_build_predictive_network():
+    net = build_snn([2, 3, 1], network_type="predictive")
+    x = np.array([0.5, -0.5])
+    out = net.forward(x)
+    assert out.shape == (1,)
+
+
+def test_energy_schedule_reduces_energy():
+    net = build_snn([2, 4, 1], network_type="energy")
+    x = np.array([1.0, -1.0])
+    target = np.array([0.5])
+    e1 = net.energy(x, target)
+    schedule = LearningSchedule(lr=0.05, epochs=20)
+    train_energy(net, x, target, schedule)
+    e2 = net.energy(x, target)
+    assert e2 < e1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,3 +18,19 @@ def test_energy_schedule_reduces_energy():
     train_energy(net, x, target, schedule)
     e2 = net.energy(x, target)
     assert e2 < e1
+
+
+def test_custom_energy_fn_used():
+    def energy(out, target, weights, reg):
+        return np.sum((out - target) ** 2)
+
+    def grad(out, target):
+        return 2 * (out - target)
+
+    net = build_snn([2, 2, 1], network_type="energy", energy_fn=energy, grad_fn=grad)
+    x = np.array([0.1, 0.2])
+    target = np.array([0.0])
+    e1 = net.energy(x, target)
+    train_energy(net, x, target, LearningSchedule(lr=0.1, epochs=5))
+    e2 = net.energy(x, target)
+    assert e2 < e1


### PR DESCRIPTION
## Summary
- allow custom neuron types in `Layer` and `Network`
- expose neuron class selection in `PredictiveCodingNetwork`
- make `EnergyNetwork` accept a custom energy function
- provide new `bio_snn.api` module with `build_snn`, `LearningSchedule`, and `train_energy`
- document API usage in README
- export new helpers from package
- test the new high-level API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4547432c832ca290285e3eb5d726