### PR TITLE
Add tests and tutorial notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ This will construct a small network with the given layer sizes, feed the input
 vector for 100 steps and print the final output.  Providing a ``--seed`` ensures
 reproducible results, while ``--modulation`` can be used to adjust the strength
 of plasticity online.
+
+## Tutorial Notebooks
+
+Several Jupyter notebooks in the ``notebooks`` directory demonstrate how to
+train the ``EnergyNetwork`` on common tasks:
+
+- ``energy_image_reconstruction.ipynb`` shows a tiny autoencoder that
+  reconstructs 8x8 images.
+- ``energy_sequence_prediction.ipynb`` trains the network to predict the next
+  value in a numerical sequence.
+- ``energy_generative_modeling.ipynb`` illustrates how the network can learn a
+  simple one-dimensional distribution for generative modeling experiments.

--- a/notebooks/energy_generative_modeling.ipynb
+++ b/notebooks/energy_generative_modeling.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d838b26d",
+   "metadata": {},
+   "source": [
+    "# Energy-Based Generative Modeling\n",
+    "\n",
+    "Train an `EnergyNetwork` to generate samples that match a one-dimensional distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9e1f5d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from bio_snn.energy_based import EnergyNetwork"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5077e466",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = np.random.normal(0, 1, 100)\n",
+    "net = EnergyNetwork([1, 8, 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "514e8111",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x in data:\n",
+    "    for _ in range(10):\n",
+    "        net.train_step(np.array([x]), np.array([x]), lr=0.05)\n",
+    "print('Sample after training:', net.forward(np.array([0.0])))"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/energy_image_reconstruction.ipynb
+++ b/notebooks/energy_image_reconstruction.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8151465e",
+   "metadata": {},
+   "source": [
+    "# Energy-Based Image Reconstruction\n",
+    "\n",
+    "This example trains a simple `EnergyNetwork` to reconstruct 8x8 images using gradient descent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "010310b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from bio_snn.energy_based import EnergyNetwork"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6813ed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a toy dataset of 8x8 binary images\n",
+    "images = np.random.randint(0, 2, (10, 64)).astype(float)\n",
+    "net = EnergyNetwork([64, 32, 64])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111a89bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# training loop\n",
+    "for img in images:\n",
+    "    for _ in range(50):\n",
+    "        net.train_step(img, img, lr=0.1)\n",
+    "print('Energy on first image:', net.energy(images[0], images[0]))"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/energy_sequence_prediction.ipynb
+++ b/notebooks/energy_sequence_prediction.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ef9889e9",
+   "metadata": {},
+   "source": [
+    "# Energy-Based Sequence Prediction\n",
+    "\n",
+    "Use an `EnergyNetwork` to predict the next value in a short numerical sequence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6403a361",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from bio_snn.energy_based import EnergyNetwork"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3756f849",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seq = np.sin(np.linspace(0, 4*np.pi, 20))\n",
+    "inputs = np.stack([seq[:-1], seq[1:]], axis=1)\n",
+    "net = EnergyNetwork([2, 16, 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65bbeba0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x, target in inputs:\n",
+    "    for _ in range(20):\n",
+    "        net.train_step(x, np.array([target]), lr=0.05)\n",
+    "print('Prediction for first step:', net.forward(inputs[0]))"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -17,3 +17,36 @@ def test_reset_restores_baseline():
     n.reset()
     assert n.v == n.v_reset
     assert n.threshold == n.baseline_thresh
+
+
+def test_adaptive_threshold_increases_then_decays():
+    n = SpikingNeuron()
+    # repeatedly provide strong input to trigger a spike
+    spike = 0
+    for _ in range(5):
+        spike = n.forward([5.0])
+        if spike:
+            break
+    assert spike == 1
+    increased = n.threshold
+    assert increased > n.baseline_thresh
+
+    # run without input to allow decay toward baseline
+    for _ in range(100):
+        n.forward([0.0])
+    assert n.threshold < increased
+    assert abs(n.threshold - n.baseline_thresh) < 0.05
+
+
+def test_last_spike_tracking():
+    n = SpikingNeuron()
+    assert n.last_spike == -float('inf')
+    # ensure a spike occurs
+    for _ in range(5):
+        if n.forward([5.0]):
+            break
+    assert n.last_spike == 0.0
+    # after a few steps without spikes the timer should increase
+    for _ in range(3):
+        n.forward([0.0])
+    assert n.last_spike > 0

--- a/tests/test_predictive_coding.py
+++ b/tests/test_predictive_coding.py
@@ -17,3 +17,19 @@ def test_network_reset_clears_traces():
     assert any(layer.post_traces.any() for layer in net.layers)
     net.reset_state()
     assert all(not layer.post_traces.any() for layer in net.layers)
+
+
+def test_prediction_weights_update_and_reset():
+    net = PredictiveCodingNetwork([2, 3, 1])
+    # boost layer weights so neurons fire
+    for layer in net.layers:
+        layer.weights.fill(1.0)
+    x = np.array([1.0, 1.0])
+    assert all(not w.any() for w in net.pred_weights)
+    for _ in range(10):
+        net.forward(x)
+    # after multiple steps prediction weights should be updated
+    assert any(w.any() for w in net.pred_weights)
+    net.reset_state()
+    # reset clears prediction weights
+    assert all(not w.any() for w in net.pred_weights)


### PR DESCRIPTION
## Summary
- broaden neuron tests for adaptive threshold & spike timing
- extend predictive coding tests to exercise prediction weights
- add tutorial notebooks covering image reconstruction, sequence prediction, and generative modeling
- mention tutorials in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4548c0d8832ca44aa990d3b582e1