### PR TITLE
Add dataset gatherer utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ This will load the dataset, run several training epochs while logging loss
 values, save checkpoints in ``./checkpoints`` and produce a ``training_loss.png``
 plot for quick visualization.
 
+### Preparing the dataset
+
+For quick experiments you can pre-generate the digits dataset splits using the
+``scripts/gather_digits_dataset.py`` helper:
+
+```bash
+python scripts/gather_digits_dataset.py --out-dir data --test-size 0.2 --random-state 0
+```
+
+This will create ``data/train.npz`` and ``data/test.npz`` files which can be
+loaded later with ``numpy.load`` for rapid prototyping.
+
 ### PyTorch implementation
 
 For experiments requiring automatic differentiation or more advanced optimizers,

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -10,7 +10,7 @@ from .modular_network import ModularEnergyNetwork
 from .layers import DenseLayer, ConvLayer, FlattenLayer, RecurrentLayer
 from .energy_predictive import EnergyPredictiveNetwork
 from .interface import run_simulation
-from .datasets import load_digits_dataset
+from .datasets import load_digits_dataset, gather_digits_dataset
 from .training import EnergyTrainer, TrainingConfig
 from .torch_energy import TorchEnergyNetwork
 
@@ -29,6 +29,7 @@ __all__ = [
     "EnergyPredictiveNetwork",
     "run_simulation",
     "load_digits_dataset",
+    "gather_digits_dataset",
     "EnergyTrainer",
     "TrainingConfig",
 ]

--- a/bio_snn/datasets/__init__.py
+++ b/bio_snn/datasets/__init__.py
@@ -1,5 +1,5 @@
 """Dataset loaders and preprocessing utilities for standard ML datasets."""
 
-from .digits import load_digits_dataset
+from .digits import load_digits_dataset, gather_digits_dataset
 
-__all__ = ["load_digits_dataset"]
+__all__ = ["load_digits_dataset", "gather_digits_dataset"]

--- a/bio_snn/datasets/digits.py
+++ b/bio_snn/datasets/digits.py
@@ -1,6 +1,7 @@
 """Utilities for loading and preprocessing the sklearn digits dataset."""
 
 from typing import Tuple
+from pathlib import Path
 import numpy as np
 from sklearn.datasets import load_digits
 from sklearn.model_selection import train_test_split
@@ -41,3 +42,34 @@ def load_digits_dataset(test_size: float = 0.25, random_state: int | None = None
     X_test = scaler.transform(X_test)
 
     return X_train, X_test, y_train, y_test
+
+
+def gather_digits_dataset(out_dir: str | Path = "data", test_size: float = 0.25,
+                          random_state: int | None = None
+                          ) -> Tuple[Path, Path]:
+    """Save train/test splits of the digits dataset to ``out_dir``.
+
+    Parameters
+    ----------
+    out_dir:
+        Directory where ``train.npz`` and ``test.npz`` will be written.
+    test_size: float, default 0.25
+        Fraction of the dataset reserved for testing.
+    random_state: int or None, optional
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    train_path: Path to the saved training set.
+    test_path: Path to the saved test set.
+    """
+    X_train, X_test, y_train, y_test = load_digits_dataset(
+        test_size=test_size, random_state=random_state
+    )
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    train_path = out_dir / "train.npz"
+    test_path = out_dir / "test.npz"
+    np.savez_compressed(train_path, X=X_train, y=y_train)
+    np.savez_compressed(test_path, X=X_test, y=y_test)
+    return train_path, test_path

--- a/scripts/gather_digits_dataset.py
+++ b/scripts/gather_digits_dataset.py
@@ -1,0 +1,25 @@
+import argparse
+from bio_snn.datasets.digits import gather_digits_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download digits dataset and save train/test splits"
+    )
+    parser.add_argument("--out-dir", default="data", help="Output directory")
+    parser.add_argument("--test-size", type=float, default=0.25,
+                        help="Fraction reserved for testing")
+    parser.add_argument("--random-state", type=int, default=None,
+                        help="Random seed for reproducibility")
+    args = parser.parse_args()
+    train_path, test_path = gather_digits_dataset(
+        out_dir=args.out_dir,
+        test_size=args.test_size,
+        random_state=args.random_state,
+    )
+    print(f"Saved training data to {train_path}")
+    print(f"Saved testing data to {test_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gather_dataset.py
+++ b/tests/test_gather_dataset.py
@@ -1,0 +1,7 @@
+from bio_snn.datasets import gather_digits_dataset
+
+
+def test_gather_digits_dataset(tmp_path):
+    train_path, test_path = gather_digits_dataset(out_dir=tmp_path, test_size=0.2, random_state=0)
+    assert train_path.exists()
+    assert test_path.exists()


### PR DESCRIPTION
## Summary
- add `gather_digits_dataset` to dataset utilities
- provide a CLI script to save train/test splits
- document how to prepare the data
- export the new helper from package
- test the gather function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4e53baf8832caafc431ae45c5b0e