### PR TITLE
Add JEPA-like features

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,22 @@ train the ``EnergyNetwork`` on common tasks:
   value in a numerical sequence.
 - ``energy_generative_modeling.ipynb`` illustrates how the network can learn a
   simple one-dimensional distribution for generative modeling experiments.
+
+## JEPA-style Training
+
+The package includes a lightweight `JointEmbeddingNetwork` for simple joint embedding predictive experiments. It shares an encoder for context and target inputs and learns to predict the target embedding from the context.
+
+```python
+from bio_snn.jepa import JointEmbeddingNetwork
+import numpy as np
+
+net = JointEmbeddingNetwork([2, 4, 2])
+ctx = np.array([1.0, 0.0])
+tgt = np.array([0.5, -0.5])
+for _ in range(50):
+    net.train_step(ctx, tgt, lr=0.05)
+loss = net.loss(ctx, tgt)
+print("Loss:", loss)
+```
+
+This trains the network so that the predicted embedding matches the target embedding.

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -9,6 +9,7 @@ from .api import SNNModel
 from .modular_network import ModularEnergyNetwork
 from .layers import DenseLayer, ConvLayer, FlattenLayer, RecurrentLayer
 from .energy_predictive import EnergyPredictiveNetwork
+from .jepa import JointEmbeddingNetwork
 from .interface import run_simulation
 from .datasets import load_digits_dataset, gather_digits_dataset
 from .training import EnergyTrainer, TrainingConfig
@@ -32,4 +33,5 @@ __all__ = [
     "gather_digits_dataset",
     "EnergyTrainer",
     "TrainingConfig",
+    "JointEmbeddingNetwork",
 ]

--- a/bio_snn/jepa.py
+++ b/bio_snn/jepa.py
@@ -1,0 +1,40 @@
+import numpy as np
+from .energy_based import EnergyNetwork
+
+class JointEmbeddingNetwork:
+    """Minimal JEPA-style network with shared encoder and predictor."""
+
+    def __init__(self, encoder_sizes, predictor_sizes=None):
+        self.encoder = EnergyNetwork(encoder_sizes)
+        pred_sizes = predictor_sizes if predictor_sizes is not None else [encoder_sizes[-1], encoder_sizes[-1]]
+        self.predictor = EnergyNetwork(pred_sizes)
+
+    def forward(self, context, target):
+        """Return predicted and target embeddings."""
+        ctx_z = self.encoder.forward(context)
+        tgt_z = self.encoder.forward(target)
+        pred_z = self.predictor.forward(ctx_z)
+        return pred_z, tgt_z
+
+    def loss(self, context, target):
+        pred_z, tgt_z = self.forward(context, target)
+        diff = pred_z - tgt_z
+        return 0.5 * float(np.sum(diff ** 2))
+
+    def train_step(self, context, target, lr=0.01):
+        """Update network parameters to minimize prediction loss."""
+        ctx_z, ctx_acts = self.encoder.forward_activations(context)
+        tgt_z, tgt_acts = self.encoder.forward_activations(target)
+        pred_z, pred_acts = self.predictor.forward_activations(ctx_z)
+
+        diff = pred_z - tgt_z
+
+        pred_grads, grad_ctx = self.predictor.backprop(pred_acts, diff)
+        self.predictor.apply_grads(pred_grads, lr)
+
+        enc_grads_ctx, _ = self.encoder.backprop(ctx_acts, grad_ctx)
+        enc_grads_tgt, _ = self.encoder.backprop(tgt_acts, -diff)
+        enc_grads = [gc + gt for gc, gt in zip(enc_grads_ctx, enc_grads_tgt)]
+        self.encoder.apply_grads(enc_grads, lr)
+
+        return 0.5 * float(np.sum(diff ** 2))

--- a/tests/test_jepa.py
+++ b/tests/test_jepa.py
@@ -1,0 +1,21 @@
+import numpy as np
+from bio_snn.jepa import JointEmbeddingNetwork
+
+
+def test_jepa_forward_shapes():
+    net = JointEmbeddingNetwork([2, 4, 2])
+    ctx = np.array([0.5, -0.5])
+    tgt = np.array([-0.2, 0.1])
+    pred, target = net.forward(ctx, tgt)
+    assert pred.shape == target.shape == (2,)
+
+
+def test_jepa_training_reduces_loss():
+    net = JointEmbeddingNetwork([2, 4, 2])
+    ctx = np.array([1.0, -1.0])
+    tgt = np.array([0.5, 0.5])
+    l1 = net.loss(ctx, tgt)
+    for _ in range(20):
+        net.train_step(ctx, tgt, lr=0.05)
+    l2 = net.loss(ctx, tgt)
+    assert l2 < l1


### PR DESCRIPTION
## Summary
- implement `JointEmbeddingNetwork` as a simple JEPA-style module
- export the new class
- document JEPA-style training example in the README
- test the new network
- implement proper backprop for JEPA training

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e5830bb98832ca86d88860cb55b97