### PR TITLE
Add additional tests and optional torch import

### DIFF
--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -5,7 +5,10 @@ from .network import Network
 from .predictive_coding import PredictiveCodingNetwork
 from .energy_based import EnergyNetwork
 from .core import BaseEnergyNetwork
-from .torch_energy import TorchEnergyNetwork
+try:
+    from .torch_energy import TorchEnergyNetwork
+except Exception:  # pragma: no cover - torch is optional
+    TorchEnergyNetwork = None
 from .api import SNNModel
 from .modular_network import ModularEnergyNetwork
 from .layers import DenseLayer, ConvLayer, FlattenLayer, RecurrentLayer
@@ -14,7 +17,6 @@ from .jepa import JointEmbeddingNetwork
 from .interface import run_simulation
 from .datasets import load_digits_dataset, gather_digits_dataset
 from .training import EnergyTrainer, TrainingConfig
-from .torch_energy import TorchEnergyNetwork
 
 __all__ = [
     "SpikingNeuron",

--- a/bio_snn/__init__.py
+++ b/bio_snn/__init__.py
@@ -7,7 +7,7 @@ from .energy_based import EnergyNetwork
 from .core import BaseEnergyNetwork
 try:
     from .torch_energy import TorchEnergyNetwork
-except Exception:  # pragma: no cover - torch is optional
+except ImportError:  # pragma: no cover - torch is optional
     TorchEnergyNetwork = None
 from .api import SNNModel
 from .modular_network import ModularEnergyNetwork

--- a/tests/test_api_extra.py
+++ b/tests/test_api_extra.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from bio_snn.api import SNNModel
+from bio_snn.layers import DenseLayer
+
+
+def test_predict_before_compile_raises():
+    model = SNNModel()
+    with pytest.raises(RuntimeError):
+        model.predict(np.array([0.0]))
+
+
+def test_layers_property_after_compile():
+    model = SNNModel()
+    model.add_layer(DenseLayer, 2, 3)
+    model.add_layer(DenseLayer, 3, 1)
+    model.compile(lr=0.01)
+    layers = model.layers
+    assert len(layers) == 2
+    assert all(hasattr(l, "forward") for l in layers)

--- a/tests/test_core_and_plasticity.py
+++ b/tests/test_core_and_plasticity.py
@@ -1,0 +1,54 @@
+import numpy as np
+from bio_snn.plasticity import STDP, SynapticScaling
+from bio_snn.network import Layer
+from bio_snn.core import BaseEnergyNetwork
+
+
+def test_stdp_weight_update_with_post_spike():
+    stdp = STDP(lr=0.1, tau_pre=20.0, tau_post=20.0)
+    w, pre_t, post_t = stdp.update(0.5, pre_spike=1, post_spike=0,
+                                   pre_trace=0.0, post_trace=0.0)
+    assert np.isclose(w, 0.5)
+    w2, pre_t, post_t = stdp.update(w, pre_spike=0, post_spike=1,
+                                    pre_trace=pre_t, post_trace=post_t)
+    assert w2 < w
+
+
+def test_synaptic_scaling_adjusts_weights():
+    scaling = SynapticScaling(target=0.1, lr=0.5)
+    w = np.array([1.0, 2.0])
+    w_new = scaling.update(w, rate=0.0)
+    expected = w * (1 + 0.5 * (0.1 - 0.0))
+    assert np.allclose(w_new, expected)
+
+
+def test_layer_reset_state_clears_activity():
+    layer = Layer(1, 1)
+    layer.weights.fill(5.0)
+    layer.forward(np.array([2.0]))
+    assert layer.pre_traces.any() and layer.post_traces.any()
+    assert layer.avg_rates.any()
+    layer.reset_state()
+    assert not layer.pre_traces.any()
+    assert not layer.post_traces.any()
+    assert not layer.avg_rates.any()
+    n = layer.neurons[0]
+    assert n.v == n.v_reset
+    assert n.threshold == n.baseline_thresh
+    assert n.last_spike == -float("inf")
+
+
+def test_core_backprop_and_apply_grads():
+    net = BaseEnergyNetwork([2, 3, 1], reg=0.0)
+    x = np.array([0.1, -0.2])
+    out, activations = net.forward_activations(x)
+    assert np.allclose(out, net.forward(x))
+    grad_out = np.array([0.5])
+    grads, grad_x = net.backprop(activations, grad_out)
+    old = [w.copy() for w in net.weights]
+    net.apply_grads(grads, lr=0.1)
+    for o, n, g in zip(old, net.weights, grads):
+        assert np.allclose(n, o - 0.1 * g)
+    assert len(grads) == len(net.weights)
+    for g, w in zip(grads, old):
+        assert g.shape == w.shape

--- a/tests/test_layers_ops.py
+++ b/tests/test_layers_ops.py
@@ -1,0 +1,57 @@
+import numpy as np
+from bio_snn.layers import DenseLayer, FlattenLayer, ConvLayer, RecurrentLayer
+
+
+def test_dense_layer_forward_backward_update():
+    layer = DenseLayer(2, 1)
+    layer.weight.fill(0.5)
+    x = np.array([1.0, -1.0])
+    out = layer.forward(x)
+    assert out.shape == (1,)
+    assert np.allclose(out, [0.0])
+
+    grad_x = layer.backward(np.array([1.0]))
+    assert np.allclose(layer.grad_w, np.array([[1.0, -1.0]]))
+    old = layer.weight.copy()
+    layer.update(lr=0.1)
+    assert np.allclose(layer.weight, old - 0.1 * layer.grad_w)
+    assert grad_x.shape == x.shape
+
+
+def test_flatten_layer_round_trip():
+    layer = FlattenLayer()
+    x = np.array([[1, 2], [3, 4]])
+    flat = layer.forward(x)
+    assert flat.shape == (4,)
+    grad = layer.backward(np.arange(4))
+    assert grad.shape == (2, 2)
+
+
+def test_conv_layer_forward_backward_shapes():
+    conv = ConvLayer(1, 1, kernel_size=2)
+    conv.weight.fill(1.0)
+    x = np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=float)
+    out = conv.forward(x)
+    assert out.shape == (1, 2, 2)
+    expected = np.array([[[12, 16], [24, 28]]], dtype=float)
+    assert np.allclose(out, expected)
+
+    grad_x = conv.backward(np.ones((1, 2, 2)))
+    assert conv.grad_w.shape == conv.weight.shape
+    assert grad_x.shape == x.shape
+
+
+def test_recurrent_layer_state_update_and_reset():
+    rnn = RecurrentLayer(1, 2)
+    rnn.w_in.fill(0.5)
+    rnn.w_rec.fill(0.0)
+    x = np.array([1.0])
+    h1 = rnn.forward(x)
+    assert h1.shape == (2,)
+    grad_x = rnn.backward(np.ones(2))
+    old_w = rnn.w_in.copy()
+    rnn.update(0.1)
+    assert not np.allclose(old_w, rnn.w_in)
+    assert grad_x.shape == x.shape
+    rnn.reset_state()
+    assert np.allclose(rnn.h, np.zeros_like(rnn.h))

--- a/tests/test_network_extra.py
+++ b/tests/test_network_extra.py
@@ -1,0 +1,21 @@
+import numpy as np
+from bio_snn.network import Network
+
+
+def test_network_forward_updates_weights():
+    net = Network([1, 1])
+    before = net.layers[0].weights.copy()
+    out = net.forward(np.array([1.0]))
+    assert out.shape == (1,)
+    after = net.layers[0].weights
+    assert not np.allclose(before, after)
+
+
+def test_network_reset_state_clears_layers():
+    net = Network([1, 1])
+    net.forward(np.array([2.0]))
+    net.reset_state()
+    layer = net.layers[0]
+    assert not layer.pre_traces.any()
+    assert not layer.post_traces.any()
+    assert not layer.avg_rates.any()

--- a/tests/test_torch_energy.py
+++ b/tests/test_torch_energy.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")

--- a/tests/test_torch_energy.py
+++ b/tests/test_torch_energy.py
@@ -1,5 +1,7 @@
 import numpy as np
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
 from bio_snn.torch_energy import TorchEnergyNetwork
 
 

--- a/tests/test_training_extra.py
+++ b/tests/test_training_extra.py
@@ -1,0 +1,22 @@
+from bio_snn.training import EnergyTrainer, TrainingConfig
+
+
+def test_batch_iter_produces_all_samples(tmp_path):
+    cfg = TrainingConfig(
+        sizes=[64, 16, 10], epochs=0, batch_size=20, checkpoint_dir=tmp_path
+    )
+    trainer = EnergyTrainer(cfg)
+    count = 0
+    for x_batch, y_batch in trainer._batch_iter():
+        assert x_batch.shape[0] <= 20
+        assert x_batch.ndim == 2
+        assert y_batch.ndim == 1
+        count += len(x_batch)
+    assert count == len(trainer.X_train)
+
+
+def test_training_creates_plot(tmp_path):
+    cfg = TrainingConfig(sizes=[64, 16, 10], epochs=1, checkpoint_dir=tmp_path, lr=0.05)
+    trainer = EnergyTrainer(cfg)
+    trainer.train()
+    assert any(tmp_path.glob("training_loss.png"))


### PR DESCRIPTION
## Summary
- avoid failing import when torch isn't installed
- skip TorchEnergyNetwork tests if torch unavailable
- cover plasticity and core utilities with new tests
- expand test coverage across layers, Network class, API model, and training utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e64621820832cb8426dc8e41c0b84